### PR TITLE
chore: add git pre-commit and pre-push hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ version = "0.1.0"
 dependencies = [
  "async-openai",
  "async-trait",
+ "cargo-husky",
  "derive_builder",
  "dotenv",
  "futures",
@@ -185,6 +186,12 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ futures = "0.3"
 async-openai = { version = "0.29.3", optional = true }
 
 [dev-dependencies]
+cargo-husky = { version = "1", features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"] }
 dotenv = "0.15.0"
 tokio = { version = "1.46.1", features = ["full"]}
 tempfile = "3.10.1"


### PR DESCRIPTION
## Description

This PR adds a Git hook that automatically runs `cargo fmt`, `cargo clippy`, and `cargo test` before commits and pushes.  

The goal is to prevent unnecessary CI failures caused by forgetting to run these checks locally before opening a PR.

## Related Issue

### None

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.