### PR TITLE
feat(core): Reasoning Effort Support and Reasoning Content Handling for OpenAI

### DIFF
--- a/src/core/language_model/generate_text.rs
+++ b/src/core/language_model/generate_text.rs
@@ -66,6 +66,15 @@ impl<M: LanguageModel> LanguageModelRequest<M> {
                             .messages
                             .push(TaggedMessage::new(options.current_step_id, assistant_msg));
                     }
+                    LanguageModelResponseContentType::Reasoning(reason) => {
+                        let assistant_msg = Message::Assistant(AssistantMessage {
+                            content: reason.clone().into(),
+                            usage: response.usage.clone(),
+                        });
+                        options
+                            .messages
+                            .push(TaggedMessage::new(options.current_step_id, assistant_msg));
+                    }
                     LanguageModelResponseContentType::ToolCall(tool_info) => {
                         // add tool message
                         let usage = response.usage.clone();
@@ -76,7 +85,6 @@ impl<M: LanguageModel> LanguageModelRequest<M> {
                                 usage,
                             )),
                         ));
-
                         options.handle_tool_call(tool_info).await;
                     }
                     _ => (),

--- a/src/core/language_model/request.rs
+++ b/src/core/language_model/request.rs
@@ -242,6 +242,14 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, OptionsStage> {
         self
     }
 
+    pub fn reasoning_effort(
+        mut self,
+        reasoning_effort: impl Into<crate::core::language_model::ReasoningEffort>,
+    ) -> Self {
+        self.reasoning_effort = Some(reasoning_effort.into());
+        self
+    }
+
     pub fn build(self) -> LanguageModelRequest<M> {
         let model = self
             .model

--- a/src/core/language_model/stream_text.rs
+++ b/src/core/language_model/stream_text.rs
@@ -73,6 +73,18 @@ impl<M: LanguageModel> LanguageModelRequest<M> {
                                             ));
                                             options.stop_reason = Some(StopReason::Finish);
                                         }
+                                        LanguageModelResponseContentType::Reasoning(ref reason) => {
+                                            options.messages.push(TaggedMessage::new(
+                                                options.current_step_id,
+                                                Message::Assistant(AssistantMessage {
+                                                    content:
+                                                        LanguageModelResponseContentType::Reasoning(
+                                                            reason.clone(),
+                                                        ),
+                                                    usage: final_msg.usage.clone(),
+                                                }),
+                                            ))
+                                        }
                                         LanguageModelResponseContentType::ToolCall(
                                             ref tool_info,
                                         ) => {


### PR DESCRIPTION
This PR introduces full support for OpenAI reasoning models (e.g., o1-mini) by adding a ReasoningEffort configuration and handling reasoning-type responses across the SDK.

## Key Changes:
- Added ReasoningEffort enum (Low, Medium, High) to LanguageModelOptions and builder API.
- Integrated reasoning configuration into OpenAI request conversion (ReasoningConfig, ReasoningSummary, OpenAIReasoningEffort).
- Added Reasoning variant to LanguageModelResponseContentType and ensured proper message handling in text and streaming flows.
- Updated tests and integration tests to cover reasoning conversion, usage tokens, and reasoning-aware callbacks.
- Renamed integration test to include reasoning and added new tests for reasoning models and streaming behavior.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.