### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ Changelog entries are grouped by type, with the following types:
 
 ## [Unreleased] - ReleaseDate
 
+## [0.3.0] - 2025-12-29
+
 ### Added
 - Added `Messages` type alias for `Vec<Message>`.
-- Added semlesss integration to work with vercel's ai-sdk-ui.
+- Added seamless integration to work with vercel's ai-sdk-ui.
 - Added seamless integration to work with axum + vercel's ai-sdk ui.
 - Added Google provider
 - Added `Extensions` struct for attaching provider-specific metadata to core SDK structures
@@ -69,7 +71,8 @@ Changelog entries are grouped by type, with the following types:
 - Rebranded to aisdk
 
 <!-- next-url -->
-[Unreleased]: https://github.com/lazy-hq/aisdk/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/lazy-hq/aisdk/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/lazy-hq/aisdk/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/lazy-hq/aisdk/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/lazy-hq/aisdk/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/lazy-hq/aisdk/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aisdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aisdk-macros",
  "async-trait",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "aisdk-macros"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aisdk",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "aisdk"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 description = "An open-source Rust library for building AI-powered applications, inspired by the Vercel AI SDK. It provides a robust, type-safe, and easy-to-use interface for interacting with various Large Language Models (LLMs)."
@@ -41,7 +41,7 @@ reqwest-eventsource = "0.6.0"
 uuid = { version = "1.0", features = ["v4"] }
 axum = { version = ">=0.7, <0.9", optional = true }
 parking_lot = "0.12.5"
-aisdk-macros = { version = "0.2.1", path = "./macros" }
+aisdk-macros = { version = "0.3.0", path = "./macros" }
 
 [dev-dependencies]
 cargo-husky = { version = "1", features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"] }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aisdk-macros"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 description = "Procedural macros for the aisdk library"
@@ -19,7 +19,7 @@ quote = "1.0"
 [dev-dependencies]
 serde_json = "1.0"
 tokio = { version = "1.46.1", features = ["full"]}
-aisdk = {path = "..", version = "0.2.1"}
+aisdk = {path = "..", version = "0.3.0" }
 
 [[test]]
 name = "test_tools"


### PR DESCRIPTION
Bump version to 0.3.0 and update changelog.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR releases version 0.3.0 by bumping the version across all package manifests and updating the changelog with the release date.

- Version bumped consistently from `0.2.1` to `0.3.0` in `Cargo.toml`, `macros/Cargo.toml`, and `Cargo.lock`
- Added `[0.3.0]` section in `CHANGELOG.md` with release date 2025-12-29
- Fixed typo in changelog: "semlesss" → "seamless"
- Updated version comparison links in changelog footer

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a standard release PR with consistent version bumps across all files, proper changelog updates, and no functional code changes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Added version 0.3.0 section with release date and fixed typo in feature description |
| Cargo.toml | Bumped main package version and aisdk-macros dependency to 0.3.0 |
| macros/Cargo.toml | Bumped macros package version and aisdk dev-dependency to 0.3.0 |
| Cargo.lock | Updated lockfile with version 0.3.0 for both aisdk and aisdk-macros packages |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Release as Release Tool
    participant Cargo as Cargo.toml
    participant Macros as macros/Cargo.toml
    participant Lock as Cargo.lock
    participant CL as CHANGELOG.md
    
    Dev->>Release: Trigger release 0.3.0
    Release->>Cargo: Update version to 0.3.0
    Release->>Macros: Update version to 0.3.0
    Release->>Macros: Update aisdk dependency to 0.3.0
    Release->>CL: Add [0.3.0] section with date
    Release->>CL: Fix typo: semlesss → seamless
    Release->>CL: Update comparison links
    Release->>Lock: Update aisdk version to 0.3.0
    Release->>Lock: Update aisdk-macros version to 0.3.0
    Release->>Dev: Release commit ready
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->