### PR TITLE
feat: add headers parameter for custom HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Changelog entries are grouped by type, with the following types:
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+- Added `headers` parameter to `LanguageModelOptions` for additional HTTP headers
+  - `headers()` method on request builder to set custom HTTP headers per request
+  - Headers are passed through to all HTTP-based providers (OpenAI, Anthropic, Google, etc.)
+
 ## [0.4.0] - 2026-01-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,6 +138,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### Custom HTTP Headers
+
+Pass custom HTTP headers to providers for authentication, tracking, or other purposes:
+
+```rust
+use std::collections::HashMap;
+use aisdk::core::LanguageModelRequest;
+use aisdk::providers::OpenAI;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = HashMap::new();
+    headers.insert("X-Custom-Header".to_string(), "my-value".to_string());
+
+    let result = LanguageModelRequest::builder()
+        .model(OpenAI::gpt_4o())
+        .prompt("Hello!")
+        .headers(headers)
+        .build()
+        .generate_text()
+        .await?;
+
+    println!("Response: {:?}", result.text());
+    Ok(())
+}
+```
+
 ### Prompts
 
 The AISDK prompt feature provides a powerful, file-based template system for managing AI prompts using the Tera template engine. It allows you to create reusable prompt templates with variable substitution, conditionals, loops, and template inclusion. See [Examples](https://aisdk.rs/docs/concepts/prompt) for more template examples. Enable with ```cargo add aisdk --features prompt```

--- a/src/core/language_model/generate_text.rs
+++ b/src/core/language_model/generate_text.rs
@@ -75,6 +75,7 @@ impl<M: LanguageModel> LanguageModelRequest<M> {
             stop_when: self.options.stop_when.clone(),
             on_step_start: self.options.on_step_start.clone(),
             on_step_finish: self.options.on_step_finish.clone(),
+            headers: self.options.headers.clone(),
             stop_reason: None,
             ..self.options
         };

--- a/src/core/language_model/request.rs
+++ b/src/core/language_model/request.rs
@@ -484,6 +484,22 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, OptionsStage> {
         self
     }
 
+    /// Sets additional HTTP headers to be sent with the request.
+    ///
+    /// Only applicable for HTTP-based providers.
+    ///
+    /// # Parameters
+    ///
+    /// * `headers` - A map of header names to values.
+    ///
+    /// # Returns
+    ///
+    /// The builder with the headers set.
+    pub fn headers(mut self, headers: std::collections::HashMap<String, String>) -> Self {
+        self.headers = Some(headers);
+        self
+    }
+
     /// Builds the `LanguageModelRequest`.
     ///
     /// This method consumes the builder and returns the configured request.

--- a/src/core/language_model/stream_text.rs
+++ b/src/core/language_model/stream_text.rs
@@ -78,6 +78,7 @@ impl<M: LanguageModel> LanguageModelRequest<M> {
             stop_when: self.options.stop_when.clone(),
             on_step_start: self.options.on_step_start.clone(),
             on_step_finish: self.options.on_step_finish.clone(),
+            headers: self.options.headers.clone(),
             stop_reason: None,
             ..self.options
         }));


### PR DESCRIPTION
🤖 Generated with [Claude Code | Opus 4.5](https://claude.ai/code) by directly reading Vercel's AI SDK's latest main branch

## TODO

- [ ] Test this for my use cases (wanted to get the PR up first)

## Summary

Adds support for custom HTTP headers on requests, matching the Vercel AI SDK pattern where `headers` is a `Record<string, string>`.

- Add `headers: Option<HashMap<String, String>>` to `LanguageModelOptions`
- Add `headers()` builder method on `LanguageModelRequest`
- Update `Client` trait to accept additional headers in `send()`/`send_and_stream()`
- Pass headers through all HTTP-based providers (OpenAI, Anthropic, Google, etc.)

## Usage
```rust
let mut headers = HashMap::new();
headers.insert("X-Custom-Header".to_string(), "value".to_string());

LanguageModelRequest::builder()
    .model(openai)
    .prompt("Hello")
    .headers(headers)
    .build()
    .generate_text()
    .await?;
```

## Test plan
- [x] All existing tests pass with new parameter
- [x] `cargo clippy --all-features` passes
- [x] `cargo fmt --all` passes

## Related Issue

Closes #78

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.