### PR TITLE
fix: pass dimensions parameter to all embedding providers

### DIFF
--- a/src/core/embedding_model/mod.rs
+++ b/src/core/embedding_model/mod.rs
@@ -19,7 +19,7 @@ pub struct EmbeddingModelOptions {
     /// The desired number of embeddings to generate. This allowed value depends on the
     /// model used and if the provider returns an error for invalid dimensions `embed`
     /// will propagate the error.
-    pub dimensions: usize,
+    pub dimensions: Option<usize>,
 }
 
 impl EmbeddingModelOptions {

--- a/src/core/embedding_model/request.rs
+++ b/src/core/embedding_model/request.rs
@@ -102,7 +102,7 @@ impl<M: EmbeddingModel> EmbeddingModelRequestBuilder<M> {
             model: None,
             options: EmbeddingModelOptions::builder()
                 .input(vec![])
-                .dimensions(0)
+                .dimensions(None)
                 .build()
                 .unwrap(),
             state: std::marker::PhantomData,
@@ -164,7 +164,7 @@ impl<M: EmbeddingModel> EmbeddingModelRequestBuilder<M, OptionsStage> {
         mut self,
         dimensions: usize,
     ) -> EmbeddingModelRequestBuilder<M, OptionsStage> {
-        self.options.dimensions = dimensions;
+        self.options.dimensions = Some(dimensions);
         self
     }
 

--- a/src/providers/google/conversions.rs
+++ b/src/providers/google/conversions.rs
@@ -193,7 +193,7 @@ impl From<EmbeddingModelOptions> for GoogleEmbeddingOptions {
                 },
                 task_type: None,
                 title: None,
-                output_dimensionality: None,
+                output_dimensionality: value.dimensions,
             })
             .collect();
 

--- a/src/providers/openai/client/types.rs
+++ b/src/providers/openai/client/types.rs
@@ -442,7 +442,10 @@ pub(crate) struct OpenAIEmbeddingOptions {
     // any array must be 2048 dimensions or less.
     pub input: Vec<String>,
     pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dimensions: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding_format: Option<String>,
 }

--- a/src/providers/openai/conversions.rs
+++ b/src/providers/openai/conversions.rs
@@ -184,7 +184,7 @@ impl From<EmbeddingModelOptions> for types::OpenAIEmbeddingOptions {
             input: value.input,
             model: "".to_string(), // will be set in mod.rs
             user: None,
-            dimensions: None, // TODO: add dimensions options to core options
+            dimensions: value.dimensions,
             encoding_format: None,
         }
     }

--- a/src/providers/openrouter/embedding_model.rs
+++ b/src/providers/openrouter/embedding_model.rs
@@ -27,7 +27,7 @@ impl<M: ModelName> EmbeddingModel for OpenRouter<M> {
                 input: vec![],
                 model: self.inner.options.model.clone(),
                 user: None,
-                dimensions: None,
+                dimensions: input.dimensions,
                 encoding_format: None,
             },
             _phantom: std::marker::PhantomData,

--- a/src/providers/togetherai/embedding_model.rs
+++ b/src/providers/togetherai/embedding_model.rs
@@ -27,7 +27,7 @@ impl<M: ModelName> EmbeddingModel for TogetherAI<M> {
                 input: vec![],
                 model: self.inner.options.model.clone(),
                 user: None,
-                dimensions: None,
+                dimensions: input.dimensions,
                 encoding_format: None,
             },
             _phantom: std::marker::PhantomData,

--- a/src/providers/vercel/embedding_model.rs
+++ b/src/providers/vercel/embedding_model.rs
@@ -27,7 +27,7 @@ impl<M: ModelName> EmbeddingModel for Vercel<M> {
                 input: vec![],
                 model: self.inner.options.model.clone(),
                 user: None,
-                dimensions: None,
+                dimensions: input.dimensions,
                 encoding_format: None,
             },
             _phantom: std::marker::PhantomData,

--- a/tests/provider/macros.rs
+++ b/tests/provider/macros.rs
@@ -1189,7 +1189,7 @@ macro_rules! generate_embedding_tests {
                 !result[0].is_empty(),
                 "Expected embedding vector to be non-empty"
             );
-            assert_eq!(dbg!(result.len()), 1);
+            assert_eq!(result[0].len(), 100);
 
             // Check that all values are valid floats (not NaN or infinity)
             for value in &result[0] {


### PR DESCRIPTION
## Description

Fix bug on providers. The dimentions input was not being propagated to the providers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.