### PR TITLE
fix: stream_text tool call improvements

### DIFF
--- a/src/core/language_model/mod.rs
+++ b/src/core/language_model/mod.rs
@@ -506,6 +506,10 @@ pub enum LanguageModelStreamChunkType {
     Reasoning(String),
     /// Tool call argument chunk
     ToolCall(String),
+    /// Tool call info emitted before tool execution
+    ToolCallStart(ToolCallInfo),
+    /// Tool result emitted after tool execution
+    ToolResult(ToolResultInfo),
     /// Successful completion of generation.
     End(AssistantMessage),
     /// Generation failed with an error message.

--- a/src/core/language_model/stream_text.rs
+++ b/src/core/language_model/stream_text.rs
@@ -163,7 +163,25 @@ impl<M: LanguageModel> LanguageModelRequest<M> {
                                                         usage,
                                                     )),
                                                 ));
+                                                // Emit tool call info BEFORE execution
+                                                let _ = tx.send(
+                                                    LanguageModelStreamChunkType::ToolCallStart(
+                                                        tool_info.clone(),
+                                                    ),
+                                                );
                                                 options.handle_tool_call(tool_info).await;
+                                                // Emit tool result AFTER execution (last message is the result)
+                                                if let Some(TaggedMessage {
+                                                    message: Message::Tool(result_info),
+                                                    ..
+                                                }) = options.messages.last()
+                                                {
+                                                    let _ = tx.send(
+                                                        LanguageModelStreamChunkType::ToolResult(
+                                                            result_info.clone(),
+                                                        ),
+                                                    );
+                                                }
                                                 had_tool_call = true;
                                             }
                                             _ => {}


### PR DESCRIPTION
## Summary

Two commits addressing tool call handling in `stream_text`:

- **fix: clear stop_reason when tool call follows text in stream** — When both a text block and a tool_use block arrive in a single `MessageStop` event, `Done(Text)` sets `stop_reason = Finish` before `Done(ToolCall)` is processed. This clears `stop_reason` after a tool call so the agentic loop continues and makes the follow-up API call with the tool result.

- **feat: emit ToolCallStart and ToolResult stream chunks** — Adds two new `LanguageModelStreamChunkType` variants: `ToolCallStart(ToolCallInfo)` emitted before tool execution and `ToolResult(ToolResultInfo)` emitted after. This allows consumers to display tool calls and results in real time without needing `on_step_finish` hooks or heuristic name inference.

Both changes are in the provider-agnostic `stream_text.rs` path, so they work identically across Anthropic, OpenAI, and Google providers.

## Test plan

- [ ] `cargo build` compiles successfully
- [ ] `cargo test` passes all existing tests
- [ ] Verify streaming with tool calls shows `ToolCallStart` before execution and `ToolResult` after
- [ ] Verify text + tool_use in a single message doesn't stop the agentic loop prematurely
- [ ] Verify plain text streaming (no tools) is unaffected