### PR TITLE
feat: add Mercury 2 diffusion LLM support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,3 +190,8 @@ required-features = ["togetherai", "test-access"]
 name = "xai_tests"
 path = "tests/provider/xai_tests.rs"
 required-features = ["xai", "test-access"]
+
+[[test]]
+name = "inception_tests"
+path = "tests/provider/inception_tests.rs"
+required-features = ["inception", "test-access"]

--- a/src/providers/inception/capabilities.rs
+++ b/src/providers/inception/capabilities.rs
@@ -22,5 +22,17 @@ model_capabilities! {
             display_name: "Mercury Coder",
             capabilities: [TextInputSupport, TextOutputSupport, ToolCallSupport]
         },
+        Mercury2 {
+            model_name: "mercury-2",
+            constructor_name: mercury_2,
+            display_name: "Mercury 2",
+            capabilities: [TextInputSupport, TextOutputSupport, ToolCallSupport, StructuredOutputSupport, ReasoningSupport]
+        },
+        MercuryEdit {
+            model_name: "mercury-edit",
+            constructor_name: mercury_edit,
+            display_name: "Mercury Edit",
+            capabilities: [TextInputSupport, TextOutputSupport]
+        },
     }
 }

--- a/src/providers/inception/mod.rs
+++ b/src/providers/inception/mod.rs
@@ -16,7 +16,7 @@ crate::openai_compatible_provider!(
     Inception,
     InceptionBuilder,
     InceptionProviderSettings,
-    "inception"
+    "mercury-2"
 );
 
 // Generate the language model implementation

--- a/tests/provider/inception_tests.rs
+++ b/tests/provider/inception_tests.rs
@@ -1,0 +1,20 @@
+//! Inception provider integration tests.
+use aisdk::providers::inception::{Inception, Mercury2};
+
+include!("macros.rs");
+
+generate_language_model_tests!(
+    provider: Inception,
+    api_key_var: "INCEPTION_API_KEY",
+    model_struct: Mercury2,
+    default_model: Inception::mercury_2(),
+    tool_model: Inception::mercury_2(),
+    structured_output_model: Inception::mercury_2(),
+    reasoning_model: Inception::mercury_2(),
+    embedding_model: Inception::mercury_2(),
+    skip_reasoning: false,
+    skip_tool: false,
+    skip_structured_output: false,
+    skip_streaming: false,
+    skip_embedding: true
+);


### PR DESCRIPTION
## Summary
- Adds Mercury 2 and Mercury Edit models to the Inception provider with structured output and reasoning capabilities
- Updates default Inception model from "inception" to "mercury-2"
- Adds integration test harness for Inception provider

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --all` passes
- [ ] Verify `Inception::mercury_2()` and `Inception::mercury_edit()` constructors work
- [ ] Verify Mercury 2 model has `StructuredOutputSupport` and `ReasoningSupport` capabilities