### PR TITLE
feat: rename Instant to None and add XHigh reasoning effort level

### DIFF
--- a/src/core/language_model/mod.rs
+++ b/src/core/language_model/mod.rs
@@ -578,6 +578,8 @@ pub enum StopReason {
 /// Levels of reasoning effort for language models that support it.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum ReasoningEffort {
+    /// Instant/no reasoning — near-realtime responses.
+    Instant,
     /// Low reasoning effort.
     #[default]
     Low,

--- a/src/core/language_model/mod.rs
+++ b/src/core/language_model/mod.rs
@@ -578,8 +578,8 @@ pub enum StopReason {
 /// Levels of reasoning effort for language models that support it.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum ReasoningEffort {
-    /// Instant/no reasoning — near-realtime responses.
-    Instant,
+    /// No reasoning — near-realtime responses.
+    None,
     /// Low reasoning effort.
     #[default]
     Low,
@@ -587,6 +587,8 @@ pub enum ReasoningEffort {
     Medium,
     /// High reasoning effort.
     High,
+    /// Extra-high reasoning effort (OpenAI-specific).
+    XHigh,
 }
 
 #[cfg(test)]

--- a/src/providers/anthropic/conversions.rs
+++ b/src/providers/anthropic/conversions.rs
@@ -126,6 +126,8 @@ impl From<LanguageModelOptions> for AnthropicOptions {
 
         // convert reasoning to antropic thinking
         request.thinking(options.reasoning_effort.map(|effort| match effort {
+            // Instant disables thinking entirely
+            ReasoningEffort::Instant => AnthropicThinking::Disable,
             // Low is 25% of the max_tokens
             ReasoningEffort::Low => AnthropicThinking::Enable {
                 budget_tokens: (max_tokens / 4) as usize,

--- a/src/providers/anthropic/conversions.rs
+++ b/src/providers/anthropic/conversions.rs
@@ -126,8 +126,8 @@ impl From<LanguageModelOptions> for AnthropicOptions {
 
         // convert reasoning to antropic thinking
         request.thinking(options.reasoning_effort.map(|effort| match effort {
-            // Instant disables thinking entirely
-            ReasoningEffort::Instant => AnthropicThinking::Disable,
+            // None disables thinking entirely
+            ReasoningEffort::None => AnthropicThinking::Disable,
             // Low is 25% of the max_tokens
             ReasoningEffort::Low => AnthropicThinking::Enable {
                 budget_tokens: (max_tokens / 4) as usize,
@@ -139,6 +139,10 @@ impl From<LanguageModelOptions> for AnthropicOptions {
             // High is 75% of the max_tokens
             ReasoningEffort::High => AnthropicThinking::Enable {
                 budget_tokens: (max_tokens - (max_tokens / 4)) as usize,
+            },
+            // XHigh is 90% of the max_tokens
+            ReasoningEffort::XHigh => AnthropicThinking::Enable {
+                budget_tokens: ((max_tokens * 9) / 10) as usize,
             },
         }));
 

--- a/src/providers/openai/client/types.rs
+++ b/src/providers/openai/client/types.rs
@@ -174,6 +174,7 @@ pub(crate) enum ReasoningEffort {
     Low,
     Medium,
     High,
+    #[serde(rename = "xhigh")]
     XHigh,
 }
 

--- a/src/providers/openai/conversions.rs
+++ b/src/providers/openai/conversions.rs
@@ -171,7 +171,8 @@ impl From<types::ResponseUsage> for Usage {
 impl From<ReasoningEffort> for types::ReasoningEffort {
     fn from(value: ReasoningEffort) -> Self {
         match value {
-            ReasoningEffort::Low => client::ReasoningEffort::Minimal,
+            ReasoningEffort::Instant => client::ReasoningEffort::None,
+            ReasoningEffort::Low => client::ReasoningEffort::Low,
             ReasoningEffort::Medium => client::ReasoningEffort::Medium,
             ReasoningEffort::High => client::ReasoningEffort::High,
         }
@@ -215,10 +216,17 @@ mod tests {
     };
 
     #[test]
+    fn test_reasoning_effort_conversion_instant() {
+        let effort = LMReasoningEffort::Instant;
+        let openai_effort: ReasoningEffort = effort.into();
+        assert_eq!(openai_effort, ReasoningEffort::None);
+    }
+
+    #[test]
     fn test_reasoning_effort_conversion_low() {
         let effort = LMReasoningEffort::Low;
         let openai_effort: ReasoningEffort = effort.into();
-        assert_eq!(openai_effort, ReasoningEffort::Minimal);
+        assert_eq!(openai_effort, ReasoningEffort::Low);
         let _ = openai_effort;
     }
 
@@ -237,6 +245,19 @@ mod tests {
     }
 
     #[test]
+    fn test_language_model_options_to_create_response_with_reasoning_effort_instant() {
+        let options = LanguageModelOptions {
+            reasoning_effort: Some(LMReasoningEffort::Instant),
+            ..Default::default()
+        };
+        let lm_options: OpenAILanguageModelOptions = options.into();
+        assert!(lm_options.reasoning.is_some());
+        let reasoning = lm_options.reasoning.unwrap();
+        assert_eq!(reasoning.effort, Some(ReasoningEffort::None));
+        assert_eq!(reasoning.summary, Some(SummaryType::Auto));
+    }
+
+    #[test]
     fn test_language_model_options_to_create_response_with_reasoning_effort_low() {
         let options = LanguageModelOptions {
             reasoning_effort: Some(LMReasoningEffort::Low),
@@ -245,7 +266,7 @@ mod tests {
         let lm_options: OpenAILanguageModelOptions = options.into();
         assert!(lm_options.reasoning.is_some());
         let reasoning = lm_options.reasoning.unwrap();
-        assert_eq!(reasoning.effort, Some(ReasoningEffort::Minimal));
+        assert_eq!(reasoning.effort, Some(ReasoningEffort::Low));
         assert_eq!(reasoning.summary, Some(SummaryType::Auto));
     }
 

--- a/src/providers/openai/conversions.rs
+++ b/src/providers/openai/conversions.rs
@@ -171,10 +171,11 @@ impl From<types::ResponseUsage> for Usage {
 impl From<ReasoningEffort> for types::ReasoningEffort {
     fn from(value: ReasoningEffort) -> Self {
         match value {
-            ReasoningEffort::Instant => client::ReasoningEffort::None,
+            ReasoningEffort::None => client::ReasoningEffort::None,
             ReasoningEffort::Low => client::ReasoningEffort::Low,
             ReasoningEffort::Medium => client::ReasoningEffort::Medium,
             ReasoningEffort::High => client::ReasoningEffort::High,
+            ReasoningEffort::XHigh => client::ReasoningEffort::XHigh,
         }
     }
 }
@@ -216,8 +217,8 @@ mod tests {
     };
 
     #[test]
-    fn test_reasoning_effort_conversion_instant() {
-        let effort = LMReasoningEffort::Instant;
+    fn test_reasoning_effort_conversion_none() {
+        let effort = LMReasoningEffort::None;
         let openai_effort: ReasoningEffort = effort.into();
         assert_eq!(openai_effort, ReasoningEffort::None);
     }
@@ -245,9 +246,16 @@ mod tests {
     }
 
     #[test]
-    fn test_language_model_options_to_create_response_with_reasoning_effort_instant() {
+    fn test_reasoning_effort_conversion_xhigh() {
+        let effort = LMReasoningEffort::XHigh;
+        let openai_effort: ReasoningEffort = effort.into();
+        assert_eq!(openai_effort, ReasoningEffort::XHigh);
+    }
+
+    #[test]
+    fn test_language_model_options_to_create_response_with_reasoning_effort_none() {
         let options = LanguageModelOptions {
-            reasoning_effort: Some(LMReasoningEffort::Instant),
+            reasoning_effort: Some(LMReasoningEffort::None),
             ..Default::default()
         };
         let lm_options: OpenAILanguageModelOptions = options.into();
@@ -293,6 +301,19 @@ mod tests {
         assert!(lm_options.reasoning.is_some());
         let reasoning = lm_options.reasoning.unwrap();
         assert_eq!(reasoning.effort, Some(ReasoningEffort::High));
+        assert_eq!(reasoning.summary, Some(SummaryType::Auto));
+    }
+
+    #[test]
+    fn test_language_model_options_to_create_response_with_reasoning_effort_xhigh() {
+        let options = LanguageModelOptions {
+            reasoning_effort: Some(LMReasoningEffort::XHigh),
+            ..Default::default()
+        };
+        let lm_options: OpenAILanguageModelOptions = options.into();
+        assert!(lm_options.reasoning.is_some());
+        let reasoning = lm_options.reasoning.unwrap();
+        assert_eq!(reasoning.effort, Some(ReasoningEffort::XHigh));
         assert_eq!(reasoning.summary, Some(SummaryType::Auto));
     }
 

--- a/src/providers/openai_chat_completions/conversions.rs
+++ b/src/providers/openai_chat_completions/conversions.rs
@@ -72,6 +72,7 @@ impl From<LanguageModelOptions> for client::ChatCompletionsOptions {
 
         let reasoning_effort = options.reasoning_effort.map(|effort| {
             match effort {
+                ReasoningEffort::Instant => "instant",
                 ReasoningEffort::Low => "low",
                 ReasoningEffort::Medium => "medium",
                 ReasoningEffort::High => "high",

--- a/src/providers/openai_chat_completions/conversions.rs
+++ b/src/providers/openai_chat_completions/conversions.rs
@@ -72,10 +72,11 @@ impl From<LanguageModelOptions> for client::ChatCompletionsOptions {
 
         let reasoning_effort = options.reasoning_effort.map(|effort| {
             match effort {
-                ReasoningEffort::Instant => "instant",
+                ReasoningEffort::None => "none",
                 ReasoningEffort::Low => "low",
                 ReasoningEffort::Medium => "medium",
                 ReasoningEffort::High => "high",
+                ReasoningEffort::XHigh => "xhigh",
             }
             .to_string()
         });


### PR DESCRIPTION
## Summary
- Rename `ReasoningEffort::Instant` to `ReasoningEffort::None` to align with [OpenAI's API naming](https://github.com/vercel/ai/blob/a921fbb381cf2d19ef75ae27906f8d1cb0b8325b/packages/open-responses/src/responses/open-responses-api.ts#L36)
- Add `ReasoningEffort::XHigh` variant for extra-high reasoning effort
- Fix serde serialization for `XHigh` (`xhigh` not `x_high`)

## Provider mappings
| ReasoningEffort | OpenAI Responses | OpenAI Chat Completions | Anthropic |
|---|---|---|---|
| None | `none` | `"none"` | Thinking disabled |
| Low | `low` | `"low"` | 25% of max_tokens |
| Medium | `medium` | `"medium"` | 50% of max_tokens |
| High | `high` | `"high"` | 75% of max_tokens |
| XHigh | `xhigh` | `"xhigh"` | 90% of max_tokens |

## Test plan
- [x] All 98 unit tests pass
- [x] Verified `None` against OpenAI gpt-5.4 API
- [x] Verified `XHigh` against OpenAI gpt-5.4 API