### PR TITLE
feat: Add Codex-style OpenAI responses support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ name = "aisdk"
 version = "0.5.2"
 dependencies = [
  "aisdk-macros",
+ "async-stream",
  "async-trait",
  "axum",
  "cargo-husky",
@@ -67,6 +68,28 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ tera = { version = "1", optional = true }
 glob = { version = "0.3", optional = true }
 log = "0.4"
 async-trait = "0.1.88"
+async-stream = "0.3.6"
 serde = {version = "1.0.219", features = ["derive"]}
 serde_json = { version = "1.0" }
 schemars = "1.0.4"

--- a/src/providers/openai/client/mod.rs
+++ b/src/providers/openai/client/mod.rs
@@ -9,8 +9,13 @@ pub(crate) use types::*;
 use crate::core::client::{EmbeddingClient, LanguageModelClient};
 use crate::error::Error;
 use crate::providers::openai::{ModelName, OpenAI};
+use async_stream::try_stream;
+use futures::Stream;
+use futures::StreamExt;
 use reqwest::header::CONTENT_TYPE;
-use reqwest_eventsource::Event;
+use reqwest_eventsource::{Event, RequestBuilderExt};
+use std::collections::HashMap;
+use std::pin::Pin;
 
 impl<M: ModelName> LanguageModelClient for OpenAI<M> {
     type Response = types::OpenAIResponse;
@@ -38,6 +43,15 @@ impl<M: ModelName> LanguageModelClient for OpenAI<M> {
                 .parse()
                 .unwrap(),
         );
+
+        for (key, value) in &self.settings.extra_headers {
+            if let (Ok(header_name), Ok(header_value)) = (
+                reqwest::header::HeaderName::from_bytes(key.as_bytes()),
+                reqwest::header::HeaderValue::from_str(value),
+            ) {
+                default_headers.insert(header_name, header_value);
+            }
+        }
 
         default_headers
     }
@@ -90,6 +104,128 @@ impl<M: ModelName> LanguageModelClient for OpenAI<M> {
         matches!(event, types::OpenAiStreamEvent::ResponseCompleted { .. })
             || matches!(event, types::OpenAiStreamEvent::NotSupported(json) if json == "[END]")
             || matches!(event, types::OpenAiStreamEvent::ResponseError { .. })
+    }
+
+    async fn send_and_stream(
+        &self,
+        base_url: impl reqwest::IntoUrl,
+        additional_headers: Option<HashMap<String, String>>,
+    ) -> crate::error::Result<
+        Pin<Box<dyn Stream<Item = crate::error::Result<Self::StreamEvent>> + Send>>,
+    >
+    where
+        Self::StreamEvent: Send + 'static,
+        Self: Sync,
+    {
+        let url = crate::core::utils::join_url(base_url, &LanguageModelClient::path(self))?;
+        let is_chatgpt_codex =
+            url.as_str().contains("chatgpt.com/backend-api/codex") || url.path() == "/responses";
+
+        let mut headers = LanguageModelClient::headers(self);
+        if let Some(extra) = additional_headers {
+            let extra_map = reqwest::header::HeaderMap::try_from(&extra)
+                .map_err(|e| Error::InvalidInput(format!("Invalid headers: {}", e)))?;
+            headers.extend(extra_map);
+        }
+
+        if !is_chatgpt_codex {
+            let client = reqwest::Client::new();
+            let events_stream = client
+                .request(LanguageModelClient::method(self), url.clone())
+                .headers(headers)
+                .query(&LanguageModelClient::query_params(self))
+                .body(LanguageModelClient::body(self))
+                .eventsource()
+                .map_err(|e| Error::ApiError {
+                    status_code: None,
+                    details: format!("SSE stream error: {e}"),
+                })?;
+
+            let mapped_stream =
+                events_stream.map(|event_result| Self::parse_stream_sse(event_result));
+            let ended = std::sync::Arc::new(std::sync::Mutex::new(false));
+            let stream = mapped_stream.scan(ended, |ended, res| {
+                let mut ended = ended.lock().unwrap();
+                if *ended {
+                    return futures::future::ready(None);
+                }
+                *ended = res.as_ref().map_or(true, |evt| Self::end_stream(evt));
+                futures::future::ready(Some(res))
+            });
+
+            return Ok(Box::pin(stream));
+        }
+
+        let client = reqwest::Client::new();
+        let response = client
+            .request(LanguageModelClient::method(self), url)
+            .headers(headers)
+            .query(&LanguageModelClient::query_params(self))
+            .body(LanguageModelClient::body(self))
+            .send()
+            .await
+            .map_err(|e| Error::ApiError {
+                status_code: e.status(),
+                details: format!("SSE stream request failed: {e}"),
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Error::ApiError {
+                status_code: Some(status),
+                details: body,
+            });
+        }
+
+        let stream = try_stream! {
+            let mut buffer = String::new();
+            let mut byte_stream = response.bytes_stream();
+            while let Some(chunk) = byte_stream.next().await {
+                let bytes = chunk.map_err(|e| Error::ApiError {
+                    status_code: None,
+                    details: format!("SSE stream read failed: {e}"),
+                })?;
+                buffer.push_str(&String::from_utf8_lossy(&bytes));
+
+                while let Some(event_end) = buffer.find("\n\n") {
+                    let raw_event = buffer[..event_end].to_string();
+                    buffer.drain(..event_end + 2);
+
+                    let data = raw_event
+                        .lines()
+                        .filter_map(|line| line.strip_prefix("data:"))
+                        .map(|line| line.trim_start())
+                        .collect::<Vec<_>>()
+                        .join("\n");
+
+                    if data.trim().is_empty() {
+                        continue;
+                    }
+
+                    if data.trim() == "[DONE]" {
+                        yield types::OpenAiStreamEvent::NotSupported("[END]".to_string());
+                        continue;
+                    }
+
+                    let value: serde_json::Value =
+                        serde_json::from_str(&data).map_err(|e| Error::ApiError {
+                            status_code: None,
+                            details: format!("Invalid JSON in SSE data: {e}"),
+                        })?;
+
+                    let event = serde_json::from_value::<types::OpenAiStreamEvent>(value)
+                        .unwrap_or(types::OpenAiStreamEvent::NotSupported(data));
+                    let should_end = Self::end_stream(&event);
+                    yield event;
+                    if should_end {
+                        return;
+                    }
+                }
+            }
+        };
+
+        Ok(Box::pin(stream))
     }
 }
 

--- a/src/providers/openai/client/types.rs
+++ b/src/providers/openai/client/types.rs
@@ -7,6 +7,9 @@ use serde::{Deserialize, Serialize};
 #[builder(setter(into), build_fn(error = "Error"))]
 pub(crate) struct OpenAILanguageModelOptions {
     pub(crate) model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub(crate) instructions: Option<String>,
     #[builder(default)]
     pub(crate) input: Option<Input>, // open ai requires input to be set
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -24,6 +27,9 @@ pub(crate) struct OpenAILanguageModelOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub(crate) stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub(crate) store: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub(crate) top_p: Option<f32>,

--- a/src/providers/openai/conversions.rs
+++ b/src/providers/openai/conversions.rs
@@ -35,11 +35,32 @@ impl From<Tool> for types::ToolParams {
 
 impl From<LanguageModelOptions> for client::OpenAILanguageModelOptions {
     fn from(options: LanguageModelOptions) -> Self {
-        let items: Vec<types::InputItem> = options
+        let mut items: Vec<types::InputItem> = Vec::new();
+        let has_system_message = options
             .messages
-            .into_iter()
-            .filter_map(|m| m.message.into())
-            .collect();
+            .iter()
+            .any(|message| matches!(message.message, Message::System(_)));
+
+        if !has_system_message && let Some(system) = options.system.as_ref() {
+            let trimmed = system.trim();
+            if !trimmed.is_empty() {
+                items.push(types::InputItem::Item(types::MessageItem::InputMessage {
+                    content: vec![types::ContentType::InputText {
+                        text: trimmed.to_string(),
+                    }],
+                    role: types::Role::System,
+                    type_: "message".to_string(),
+                }));
+            }
+        }
+
+        items.extend(
+            options
+                .messages
+                .into_iter()
+                .filter_map(|m| m.message.into())
+                .collect::<Vec<_>>(),
+        );
 
         let tools: Option<Vec<types::ToolParams>> = options.tools.map(|t| {
             t.tools
@@ -59,6 +80,7 @@ impl From<LanguageModelOptions> for client::OpenAILanguageModelOptions {
 
         client::OpenAILanguageModelOptions {
             model: "".to_string(), // will be set in mod.rs
+            instructions: None,
             input: Some(types::Input::InputItemList(items)),
             text: Some(types::TextConfig {
                 verbosity: None,
@@ -73,6 +95,7 @@ impl From<LanguageModelOptions> for client::OpenAILanguageModelOptions {
             temperature: options.temperature.map(|t| t as f32 / 100.0),
             max_output_tokens: options.max_output_tokens.map(|t| t as usize),
             stream: Some(false),
+            store: None,
             top_p: options.top_p.map(|t| t as f32 / 100.0),
             tools,
         }

--- a/src/providers/openai/language_model.rs
+++ b/src/providers/openai/language_model.rs
@@ -16,6 +16,138 @@ use crate::{
 use async_trait::async_trait;
 use futures::StreamExt;
 
+fn is_chatgpt_codex_request<M: ModelName>(provider: &OpenAI<M>) -> bool {
+    let base_url = provider.settings.base_url.trim().to_ascii_lowercase();
+    let path = provider
+        .settings
+        .path
+        .as_deref()
+        .unwrap_or("/v1/responses")
+        .trim()
+        .to_ascii_lowercase();
+
+    base_url.contains("chatgpt.com/backend-api/codex") || path == "/responses"
+}
+
+fn extract_input_text_parts(content: &[types::ContentType]) -> Vec<String> {
+    content
+        .iter()
+        .filter_map(|part| match part {
+            types::ContentType::InputText { text } => {
+                let trimmed = text.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn bridge_chatgpt_codex_options(options: &mut OpenAILanguageModelOptions) {
+    options.store = Some(false);
+
+    let mut instruction_parts = Vec::<String>::new();
+    if let Some(existing) = options.instructions.take() {
+        let trimmed = existing.trim();
+        if !trimmed.is_empty() {
+            instruction_parts.push(trimmed.to_string());
+        }
+    }
+
+    if let Some(types::Input::InputItemList(items)) = options.input.as_mut() {
+        let mut retained = Vec::with_capacity(items.len());
+        for item in items.drain(..) {
+            match item {
+                types::InputItem::Item(types::MessageItem::InputMessage {
+                    content,
+                    role: types::Role::System,
+                    ..
+                }) => {
+                    instruction_parts.extend(extract_input_text_parts(&content));
+                }
+                types::InputItem::InputMessage {
+                    content,
+                    role: types::Role::System,
+                } => match content {
+                    types::InputItemContent::Text(text) => {
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            instruction_parts.push(trimmed.to_string());
+                        }
+                    }
+                    types::InputItemContent::InputItemContentList(parts) => {
+                        instruction_parts.extend(extract_input_text_parts(&parts));
+                    }
+                },
+                other => retained.push(other),
+            }
+        }
+        *items = retained;
+    }
+
+    if !instruction_parts.is_empty() {
+        options.instructions = Some(instruction_parts.join("\n\n"));
+    }
+}
+
+async fn generate_text_via_stream<M: ModelName>(
+    provider: &mut OpenAI<M>,
+    options: LanguageModelOptions,
+) -> Result<LanguageModelResponse> {
+    let mut stream = provider.stream_text(options).await?;
+    let mut contents: Vec<LanguageModelResponseContentType> = Vec::new();
+    let mut buffered_text = String::new();
+    let mut last_usage: Option<Usage> = None;
+
+    while let Some(event) = stream.next().await {
+        for chunk in event? {
+            match chunk {
+                LanguageModelStreamChunk::Delta(LanguageModelStreamChunkType::Text(delta)) => {
+                    buffered_text.push_str(&delta);
+                }
+                LanguageModelStreamChunk::Done(message) => {
+                    last_usage = message.usage.clone();
+                    match message.content {
+                        LanguageModelResponseContentType::Text(text) => {
+                            if buffered_text.trim().is_empty() {
+                                contents.push(LanguageModelResponseContentType::Text(text));
+                            }
+                        }
+                        other => contents.push(other),
+                    }
+                }
+                LanguageModelStreamChunk::Delta(LanguageModelStreamChunkType::Failed(reason)) => {
+                    return Err(crate::error::Error::ApiError {
+                        status_code: None,
+                        details: reason,
+                    });
+                }
+                LanguageModelStreamChunk::Delta(LanguageModelStreamChunkType::Incomplete(
+                    reason,
+                )) => {
+                    return Err(crate::error::Error::ApiError {
+                        status_code: None,
+                        details: reason,
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if !buffered_text.trim().is_empty() {
+        contents.insert(0, LanguageModelResponseContentType::Text(buffered_text));
+    }
+
+    Ok(LanguageModelResponse {
+        contents,
+        usage: last_usage,
+    })
+}
+
 #[async_trait]
 impl<M: ModelName> LanguageModel for OpenAI<M> {
     /// Returns the name of the model.
@@ -28,6 +160,10 @@ impl<M: ModelName> LanguageModel for OpenAI<M> {
         &mut self,
         options: LanguageModelOptions,
     ) -> Result<LanguageModelResponse> {
+        if is_chatgpt_codex_request(self) {
+            return generate_text_via_stream(self, options).await;
+        }
+
         let additional_headers = options.headers.clone();
         let mut options: OpenAILanguageModelOptions = options.into();
 
@@ -75,6 +211,9 @@ impl<M: ModelName> LanguageModel for OpenAI<M> {
     async fn stream_text(&mut self, options: LanguageModelOptions) -> Result<ProviderStream> {
         let additional_headers = options.headers.clone();
         let mut options: OpenAILanguageModelOptions = options.into();
+        if is_chatgpt_codex_request(self) {
+            bridge_chatgpt_codex_options(&mut options);
+        }
 
         options.model = self.lm_options.model.to_string();
         options.stream = Some(true);
@@ -233,6 +372,27 @@ mod tests {
         model.settings.base_url = base_url;
         model.settings.api_key = "test-key".to_string();
         model
+    }
+
+    fn test_model_with_provider_header(base_url: String) -> OpenAI<DynamicModel> {
+        OpenAI::<DynamicModel>::builder()
+            .model_name("gpt-4o-mini")
+            .api_key("test-key")
+            .base_url(base_url)
+            .header("x-provider-header", "provider-123")
+            .build()
+            .expect("model should build")
+    }
+
+    fn test_codex_model(base_url: String) -> OpenAI<DynamicModel> {
+        OpenAI::<DynamicModel>::builder()
+            .model_name("gpt-5-codex")
+            .api_key("test-key")
+            .base_url(base_url)
+            .path("/responses")
+            .header("x-codex-header", "codex-123")
+            .build()
+            .expect("model should build")
     }
 
     fn responses_api_response(content: &str) -> ResponseTemplate {
@@ -530,6 +690,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_generate_text_merges_provider_headers_into_request() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .and(header("authorization", "Bearer test-key"))
+            .and(header("x-provider-header", "provider-123"))
+            .and(body_partial_json(json!({
+                "model": "gpt-4o-mini",
+                "input": [
+                    {
+                        "role": "user",
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "Hello"
+                            }
+                        ]
+                    }
+                ]
+            })))
+            .respond_with(responses_api_response("ok"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = LanguageModelRequest::builder()
+            .model(test_model_with_provider_header(server.uri()))
+            .messages(vec![Message::User("Hello".to_string().into())])
+            .build()
+            .generate_text()
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.text().as_deref(), Some("ok"));
+    }
+
+    #[tokio::test]
     async fn test_stream_text_sends_streaming_request_without_custom_headers() {
         let (base_url, request_handle) = spawn_sse_server().await;
 
@@ -676,5 +875,50 @@ mod tests {
         assert!(request.contains("\"stream\":true"));
         assert!(request.contains("\"temperature\":0.6"));
         assert!(request.contains("\"top_p\":0.95"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_text_uses_codex_streaming_with_instructions_and_provider_headers() {
+        let (base_url, request_handle) = spawn_sse_server().await;
+
+        let response = LanguageModelRequest::builder()
+            .model(test_codex_model(base_url))
+            .system("You are a focused coding assistant")
+            .messages(vec![Message::User(
+                "Return a short answer".to_string().into(),
+            )])
+            .build()
+            .generate_text()
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.text().as_deref(), Some("Hello"));
+
+        let request = request_handle
+            .await
+            .expect("request capture should succeed");
+        assert!(request.starts_with("POST /responses HTTP/1.1"));
+        assert_eq!(
+            header_value(&request, "authorization"),
+            Some("Bearer test-key")
+        );
+        assert_eq!(header_value(&request, "x-codex-header"), Some("codex-123"));
+
+        let body = body_json(&request);
+        assert_eq!(body["model"], json!("gpt-5-codex"));
+        assert_eq!(body["store"], json!(false));
+        assert_eq!(
+            body["instructions"],
+            json!("You are a focused coding assistant")
+        );
+        assert_eq!(body["stream"], json!(true));
+
+        let input = body["input"].as_array().expect("input should be an array");
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], json!("user"));
+        assert_eq!(
+            input[0]["content"][0]["text"],
+            json!("Return a short answer")
+        );
     }
 }

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -200,6 +200,12 @@ impl<M: ModelName> OpenAIBuilder<M> {
         self
     }
 
+    /// Adds a custom header to every request for this provider instance.
+    pub fn header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.settings.extra_headers.push((key.into(), value.into()));
+        self
+    }
+
     /// Builds the OpenAI provider.
     ///
     /// Validates the configuration and creates the provider instance.

--- a/src/providers/openai/settings.rs
+++ b/src/providers/openai/settings.rs
@@ -20,6 +20,9 @@ pub struct OpenAIProviderSettings {
     /// This is useful for connecting to endpoints that use a different path,
     /// such as OpenAI Codex (`/responses`).
     pub path: Option<String>,
+
+    /// Additional headers forwarded with every request.
+    pub extra_headers: Vec<(String, String)>,
 }
 
 impl Default for OpenAIProviderSettings {
@@ -30,6 +33,7 @@ impl Default for OpenAIProviderSettings {
             base_url: "https://api.openai.com".to_string(),
             api_key: std::env::var("OPENAI_API_KEY").unwrap_or_default(),
             path: None,
+            extra_headers: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Description
- add provider-level OpenAI headers for reused custom auth/session headers
- support Codex-style `/responses` requests by bridging system prompts into `instructions` and disabling `store`
- add a manual SSE path for Codex-compatible response streaming plus focused provider tests

## Why
A downstream integration is currently carrying these changes as a local `aisdk` vendor patch in order to talk to ChatGPT Codex-compatible OpenAI endpoints. Upstreaming the behavior would let that local patch be removed once a release includes it.

## Testing
- `cargo test --features openai providers::openai::language_model::tests::`


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] Any dependent changes have been merged and published in downstream modules.