### PR TITLE
feat: SubAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog entries are grouped by type, with the following types:
 
 ### Added
 
+- Added support for SubAgents
 - Added support for custom HTTP headers in `LanguageModelRequest`, allowing request header injection and overriding provider default headers. by [@gaki2](https://github.com/gaki2)
 - Added support for custom HTTP headers in `EmbeddingModelRequest`, allowing request header injection and overriding provider default headers.
 - Add grok-4-20-beta as a model in xAI provider.

--- a/src/core/language_model/request.rs
+++ b/src/core/language_model/request.rs
@@ -4,10 +4,12 @@
 //! and options for generating text or streaming responses. It includes a type-state builder
 //! pattern to ensure requests are constructed correctly and safely.
 
+use crate::Error;
 use crate::core::Messages;
-use crate::core::capabilities::*;
 use crate::core::language_model::{LanguageModel, LanguageModelOptions};
-use crate::core::tools::Tool;
+use crate::core::tools::{Tool, ToolExecute};
+use crate::core::{ToolContext, capabilities::*};
+use futures::StreamExt;
 use schemars::{JsonSchema, schema_for};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -74,10 +76,21 @@ pub struct SystemStage {}
 /// Transitions to [`OptionsStage`] after calling [`prompt`](LanguageModelRequestBuilder::prompt) or [`messages`](LanguageModelRequestBuilder::messages).
 pub struct ConversationStage {}
 
+/// The state after setting a subagent, requiring a system prompt before options can be set.
+///
+/// Transitions to [`OptionsStage`] after calling [`system`](LanguageModelRequestBuilder::system).
+pub struct SubAgentStage {}
+
 /// The final state where additional options can be configured before building.
 ///
 /// Transitions to the completed `LanguageModelRequest` after calling [`build`](LanguageModelRequestBuilder::build).
 pub struct OptionsStage {}
+
+/// The default request-building mode for normal text generation requests.
+pub struct RequestMode {}
+
+/// The subagent-building mode for producing a subagent tool.
+pub struct SubagentMode {}
 
 /// A type-state builder for constructing `LanguageModelRequest` instances.
 ///
@@ -88,14 +101,18 @@ pub struct OptionsStage {}
 ///
 /// * `M` - The language model type.
 /// * `State` - The current builder state, determining available methods.
-pub struct LanguageModelRequestBuilder<M: LanguageModel, State = ModelStage> {
+/// * `Mode` - Whether the builder is producing a normal request or a subagent tool.
+pub struct LanguageModelRequestBuilder<M: LanguageModel, State = ModelStage, Mode = RequestMode> {
     model: Option<M>,
     prompt: Option<String>,
     options: LanguageModelOptions,
+    subagent_name: Option<String>,
+    subagent_description: Option<String>,
     state: std::marker::PhantomData<State>,
+    mode: std::marker::PhantomData<Mode>,
 }
 
-impl<M: LanguageModel, State> Deref for LanguageModelRequestBuilder<M, State> {
+impl<M: LanguageModel, State, Mode> Deref for LanguageModelRequestBuilder<M, State, Mode> {
     type Target = LanguageModelOptions;
 
     /// Dereferences to the underlying `LanguageModelOptions`.
@@ -106,7 +123,7 @@ impl<M: LanguageModel, State> Deref for LanguageModelRequestBuilder<M, State> {
     }
 }
 
-impl<M: LanguageModel, State> DerefMut for LanguageModelRequestBuilder<M, State> {
+impl<M: LanguageModel, State, Mode> DerefMut for LanguageModelRequestBuilder<M, State, Mode> {
     /// Mutably dereferences to the underlying `LanguageModelOptions`.
     ///
     /// This allows direct mutation of the options fields during building.
@@ -121,13 +138,16 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M> {
             model: None,
             prompt: None,
             options: LanguageModelOptions::default(),
+            subagent_name: None,
+            subagent_description: None,
             state: std::marker::PhantomData,
+            mode: std::marker::PhantomData,
         }
     }
 }
 
 /// Methods available in the [`ModelStage`] state.
-impl<M: LanguageModel> LanguageModelRequestBuilder<M, ModelStage> {
+impl<M: LanguageModel> LanguageModelRequestBuilder<M, ModelStage, RequestMode> {
     /// Sets the language model for the request.
     ///
     /// This is the first required step in building a request.
@@ -139,18 +159,21 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, ModelStage> {
     /// # Returns
     ///
     /// The builder in the [`SystemStage`] state.
-    pub fn model(self, model: M) -> LanguageModelRequestBuilder<M, SystemStage> {
+    pub fn model(self, model: M) -> LanguageModelRequestBuilder<M, SystemStage, RequestMode> {
         LanguageModelRequestBuilder {
             model: Some(model),
             prompt: self.prompt,
             options: self.options,
+            subagent_name: self.subagent_name,
+            subagent_description: self.subagent_description,
             state: std::marker::PhantomData,
+            mode: std::marker::PhantomData,
         }
     }
 }
 
 /// Methods available in the [`SystemStage`] state.
-impl<M: LanguageModel> LanguageModelRequestBuilder<M, SystemStage> {
+impl<M: LanguageModel> LanguageModelRequestBuilder<M, SystemStage, RequestMode> {
     /// Sets an optional system prompt for the request.
     ///
     /// The system prompt provides context or instructions to the model.
@@ -165,7 +188,7 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, SystemStage> {
     pub fn system(
         self,
         system: impl Into<String>,
-    ) -> LanguageModelRequestBuilder<M, ConversationStage> {
+    ) -> LanguageModelRequestBuilder<M, ConversationStage, RequestMode> {
         LanguageModelRequestBuilder {
             model: self.model,
             prompt: self.prompt,
@@ -173,7 +196,49 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, SystemStage> {
                 system: Some(system.into()),
                 ..self.options
             },
+            subagent_name: self.subagent_name,
+            subagent_description: self.subagent_description,
             state: std::marker::PhantomData,
+            mode: std::marker::PhantomData,
+        }
+    }
+
+    /// Switches the builder into **subagent mode**.
+    ///
+    /// A subagent is an agent that can be invoked by a parent agent as a tool.
+    /// The parent delegates a task, and the subagent executes it autonomously,
+    /// returning the result once complete.
+    ///
+    /// Subagents does not accept a direct prompt or messages at construction time.
+    /// Instead, it receives its task dynamically from the parent agent when invoked.
+    ///
+    /// # Parameters
+    ///
+    /// * `name` - A unique identifier for the subagent.
+    /// * `description` - A short description of the subagent’s purpose, used by the
+    ///   parent agent to decide when to invoke it.
+    ///
+    /// # Example
+    /// * `name` - "explore-agent"
+    /// * `description` - "Explore the codebase to have a deeper understanding of the project."
+    ///
+    /// # Returns
+    ///
+    /// The builder in [`SubAgentStage`], where only `.system()` is available next.
+    ///
+    pub fn subagent(
+        self,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> LanguageModelRequestBuilder<M, SubAgentStage, SubagentMode> {
+        LanguageModelRequestBuilder {
+            model: self.model,
+            prompt: None,
+            options: self.options,
+            subagent_name: Some(name.into()),
+            subagent_description: Some(description.into()),
+            state: std::marker::PhantomData,
+            mode: std::marker::PhantomData,
         }
     }
 
@@ -188,12 +253,18 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, SystemStage> {
     /// # Returns
     ///
     /// The builder in the [`OptionsStage`] state.
-    pub fn prompt(self, prompt: impl Into<String>) -> LanguageModelRequestBuilder<M, OptionsStage> {
+    pub fn prompt(
+        self,
+        prompt: impl Into<String>,
+    ) -> LanguageModelRequestBuilder<M, OptionsStage, RequestMode> {
         LanguageModelRequestBuilder {
             model: self.model,
             prompt: Some(prompt.into()),
             options: self.options,
+            subagent_name: self.subagent_name,
+            subagent_description: self.subagent_description,
             state: std::marker::PhantomData,
+            mode: std::marker::PhantomData,
         }
     }
 
@@ -208,7 +279,10 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, SystemStage> {
     /// # Returns
     ///
     /// The builder in the [`OptionsStage`] state.
-    pub fn messages(self, messages: Messages) -> LanguageModelRequestBuilder<M, OptionsStage> {
+    pub fn messages(
+        self,
+        messages: Messages,
+    ) -> LanguageModelRequestBuilder<M, OptionsStage, RequestMode> {
         LanguageModelRequestBuilder {
             model: self.model,
             prompt: self.prompt,
@@ -216,13 +290,16 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, SystemStage> {
                 messages: messages.into_iter().map(|msg| msg.into()).collect(),
                 ..self.options
             },
+            subagent_name: self.subagent_name,
+            subagent_description: self.subagent_description,
             state: std::marker::PhantomData,
+            mode: std::marker::PhantomData,
         }
     }
 }
 
 /// Methods available in the [`ConversationStage`] state.
-impl<M: LanguageModel> LanguageModelRequestBuilder<M, ConversationStage> {
+impl<M: LanguageModel> LanguageModelRequestBuilder<M, ConversationStage, RequestMode> {
     /// Sets a simple text prompt for the request.
     ///
     /// This method allows setting a user prompt.
@@ -235,7 +312,10 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, ConversationStage> {
     /// # Returns
     ///
     /// The builder in the [`OptionsStage`] state.
-    pub fn prompt(self, prompt: impl Into<String>) -> LanguageModelRequestBuilder<M, OptionsStage>
+    pub fn prompt(
+        self,
+        prompt: impl Into<String>,
+    ) -> LanguageModelRequestBuilder<M, OptionsStage, RequestMode>
     where
         M: TextInputSupport,
     {
@@ -243,7 +323,10 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, ConversationStage> {
             model: self.model,
             prompt: Some(prompt.into()),
             options: self.options,
+            subagent_name: self.subagent_name,
+            subagent_description: self.subagent_description,
             state: std::marker::PhantomData,
+            mode: std::marker::PhantomData,
         }
     }
 
@@ -259,7 +342,10 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, ConversationStage> {
     /// # Returns
     ///
     /// The builder in the [`OptionsStage`] state.
-    pub fn messages(self, messages: Messages) -> LanguageModelRequestBuilder<M, OptionsStage>
+    pub fn messages(
+        self,
+        messages: Messages,
+    ) -> LanguageModelRequestBuilder<M, OptionsStage, RequestMode>
     where
         M: TextInputSupport,
     {
@@ -270,13 +356,41 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, ConversationStage> {
                 messages: messages.into_iter().map(|msg| msg.into()).collect(),
                 ..self.options
             },
+            subagent_name: self.subagent_name,
+            subagent_description: self.subagent_description,
             state: std::marker::PhantomData,
+            mode: std::marker::PhantomData,
+        }
+    }
+}
+
+/// Methods available in the subagent system stage.
+impl<M: LanguageModel> LanguageModelRequestBuilder<M, SubAgentStage, SubagentMode> {
+    /// Sets the system prompt for the delegated subagent request,
+    /// defining how the subagent should behave.
+    ///
+    /// Subagents require a system prompt before they can be configured further or built.
+    pub fn system(
+        self,
+        system: impl Into<String>,
+    ) -> LanguageModelRequestBuilder<M, OptionsStage, SubagentMode> {
+        LanguageModelRequestBuilder {
+            model: self.model,
+            prompt: None,
+            options: LanguageModelOptions {
+                system: Some(system.into()),
+                ..self.options
+            },
+            subagent_name: self.subagent_name,
+            subagent_description: self.subagent_description,
+            state: std::marker::PhantomData,
+            mode: std::marker::PhantomData,
         }
     }
 }
 
 /// Methods available in the [`OptionsStage`] state.
-impl<M: LanguageModel> LanguageModelRequestBuilder<M, OptionsStage> {
+impl<M: LanguageModel, Mode> LanguageModelRequestBuilder<M, OptionsStage, Mode> {
     /// Sets the output schema for structured generation.
     ///
     /// This method configures the language model to generate output that conforms
@@ -517,8 +631,10 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, OptionsStage> {
         }
         self
     }
+}
 
-    /// Builds the `LanguageModelRequest`.
+impl<M: LanguageModel> LanguageModelRequestBuilder<M, OptionsStage, RequestMode> {
+    /// Builds a standard `LanguageModelRequest`.
     ///
     /// This method consumes the builder and returns the configured request.
     ///
@@ -535,5 +651,74 @@ impl<M: LanguageModel> LanguageModelRequestBuilder<M, OptionsStage> {
             prompt: self.prompt,
             options: self.options,
         }
+    }
+}
+
+// --------------------------------------------------------------------------------
+// SubAgent
+// --------------------------------------------------------------------------------
+
+#[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+/// Input schema for subagent tools.
+pub struct SubAgentInput {
+    /// The task prompt delegated to the subagent.
+    pub prompt: String,
+}
+
+impl<M: LanguageModel> LanguageModelRequestBuilder<M, OptionsStage, SubagentMode> {
+    /// Builds the subagent as a tool that can be provided to a parent agent.
+    pub fn build(self) -> Tool {
+        let name = self
+            .subagent_name
+            .unwrap_or_else(|| unreachable!("Subagent name is guaranteed to be set"));
+        let description = self
+            .subagent_description
+            .unwrap_or_else(|| unreachable!("Subagent description is guaranteed to be set"));
+        let model = self
+            .model
+            .unwrap_or_else(|| unreachable!("Model is guaranteed to be set"));
+        let options = self.options;
+
+        Tool::builder()
+            .name(name)
+            .description(description)
+            .input_schema(schema_for!(SubAgentInput))
+            .execute(ToolExecute::from_async(move |ctx: ToolContext, input| {
+                let prompt = input["prompt"]
+                    .as_str()
+                    .unwrap_or("The agent didn’t give the task as a prompt.");
+                let mut request = LanguageModelRequest::<M> {
+                    model: model.clone(),
+                    prompt: Some(prompt.into()),
+                    options: options.clone(),
+                };
+
+                async move {
+                    if let Some(_tx) = ctx.stream_tx() {
+                        let mut response = request.stream_text().await?;
+                        // consume the stream and send chunks to main agent
+                        {
+                            let stream = &mut response.stream;
+                            while let Some(chunk) = stream.next().await {
+                                ctx.emit(chunk).map_err(|err| {
+                                    Error::ToolCallError(format!(
+                                        "failed to emit subagent stream chunk: {err}"
+                                    ))
+                                })?;
+                            }
+                        }
+
+                        // get the final text
+                        let text = response.text().await;
+                        return Ok(text.unwrap_or_default());
+                    }
+
+                    let response = request.generate_text().await?;
+                    let text = response.text().unwrap_or_default();
+                    Ok(text)
+                }
+            }))
+            .build()
+            .unwrap()
     }
 }

--- a/src/core/language_model/stream_text.rs
+++ b/src/core/language_model/stream_text.rs
@@ -504,7 +504,7 @@ mod tests {
             execute: ToolExecute::from_sync(|_ctx: ToolContext, params: serde_json::Value| {
                 let location = params["location"]
                     .as_str()
-                    .ok_or_else(|| "missing location".to_string())?;
+                    .ok_or_else(|| crate::Error::ToolCallError("missing location".to_string()))?;
                 Ok(format!("The weather in {location} is sunny"))
             }),
         }

--- a/src/core/tools.rs
+++ b/src/core/tools.rs
@@ -126,8 +126,8 @@ impl ToolContext {
     }
 }
 
-/// The output returned by a tool executor before SDK error conversion.
-pub type ToolOutput = std::result::Result<String, String>;
+/// The output returned by a tool executor.
+pub type ToolOutput = Result<String>;
 
 /// A boxed future returned by a tool executor.
 pub type ToolFuture = Pin<Box<dyn Future<Output = ToolOutput> + Send>>;
@@ -152,8 +152,8 @@ impl ToolExecute {
     /// Calls the tool with the given input.
     pub async fn call(&self, context: ToolContext, map: Value) -> Result<String> {
         match &self.inner {
-            ToolExecuteInner::Sync(f) => (f)(context, map).map_err(Error::ToolCallError),
-            ToolExecuteInner::Async(f) => (f)(context, map).await.map_err(Error::ToolCallError),
+            ToolExecuteInner::Sync(f) => (f)(context, map),
+            ToolExecuteInner::Async(f) => (f)(context, map).await,
         }
     }
 

--- a/tests/provider/macros.rs
+++ b/tests/provider/macros.rs
@@ -582,7 +582,7 @@ macro_rules! generate_language_model_tool_tests {
         async fn test_generate_stream_with_structs() {
             skip_if_no_api_key!();
 
-            // define tool function body, should return Result<String, String>
+            // define tool function body, should return aisdk::error::Result<String>
             #[allow(unused_variables)]
             let func = ToolExecute::from_sync(|_ctx, inp: Value| {
                 // Ai SDK will pass in a json object with the following structure
@@ -632,6 +632,122 @@ macro_rules! generate_language_model_tool_tests {
                 .await;
 
             assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_subagent_with_generate_text() {
+            skip_if_no_api_key!();
+
+            #[tool]
+            /// given a code, returns the secret code
+            fn get_secret_code(code: String) -> Tool {
+                Ok(format!("{}{}", code, "getrusty".to_string()))
+            }
+
+            #[tool]
+            /// given a location, returns the weather in that location
+            fn get_weather(location: String) -> Tool {
+                Ok(format!("The weather in {} is sunny", location))
+            }
+
+            let subagent = LanguageModelRequest::builder()
+                .model($tool_model)
+                .subagent("subagent", "Find secret across the globe")
+                .system("You are a helpful assistant with access to tools.")
+                .with_tool(get_secret_code())
+                .build();
+
+            let main_agent = LanguageModelRequest::builder()
+                .model($tool_model)
+                .system("You are a helpful assistant with access to tools.")
+                .prompt("What is the secret code for lets")
+                .with_tool(get_weather())
+                .with_tool(subagent)
+                .build()
+                .generate_text()
+                .await;
+            assert!(main_agent.is_ok());
+
+            let text = main_agent.unwrap().text().unwrap();
+            println!("The secret code is: {}", text);
+            assert!(text.contains("letsgetrusty"));
+        }
+
+        #[tokio::test]
+        async fn test_subagent_with_stream_text() {
+            skip_if_no_api_key!();
+
+            #[tool]
+            /// given a code, returns the secret code
+            fn get_secret_code(code: String) -> Tool {
+                Ok(format!("{}{}", code, "getrusty".to_string()))
+            }
+
+            #[tool]
+            /// given a location, returns the weather in that location
+            fn get_weather(location: String) -> Tool {
+                Ok(format!("The weather in {} is sunny", location))
+            }
+
+            let subagent = LanguageModelRequest::builder()
+                .model($tool_model)
+                .subagent("subagent", "Find secret across the globe")
+                .system("You are a helpful assistant with access to tools.")
+                .with_tool(get_secret_code())
+                .build();
+
+            let main_agent = LanguageModelRequest::builder()
+                .model($tool_model)
+                .system("You are a helpful assistant with access to tools.")
+                .prompt("What is the secret code for lets")
+                .with_tool(get_weather())
+                .with_tool(subagent)
+                .build()
+                .stream_text()
+                .await;
+            assert!(main_agent.is_ok());
+
+            let mut response = main_agent.unwrap();
+
+            // stream chunks
+            let mut textbuf = String::new();
+            let mut tool_calls = 0;
+            let mut tool_call_deltas = String::new();
+
+            // consume the stream
+            {
+                let stream = &mut response.stream;
+
+                while let Some(chunk) = stream.next().await {
+                    if let LanguageModelStreamChunkType::TextDelta(text) = &chunk {
+                        textbuf.push_str(&text);
+                    }
+                    if let LanguageModelStreamChunkType::ToolCallStart(_) = &chunk {
+                        tool_calls += 1;
+                    }
+                    if let LanguageModelStreamChunkType::ToolCallDelta { delta, .. } = &chunk {
+                        tool_call_deltas.push_str(&delta);
+                    }
+                }
+            }
+            println!("The secret code is: {}", textbuf);
+
+            // secret code found
+            assert!(textbuf.contains("letsgetrusty"));
+
+            // 2 tool calls must have been made
+            // 1 call: to give a subagent the task
+            // 1 call: the subagent used the tool to find the secret code
+            assert_eq!(tool_calls, 2);
+
+            // the tool call delta must indicate the 2 tool call parameters (prompt and code)
+            // prompt is the task given to subagent
+            assert!(tool_call_deltas.contains("prompt"));
+            assert!(tool_call_deltas.contains("code"));
+
+            //  last text contains the secret code
+            let text = response.text().await;
+            assert!(text.unwrap().contains("letsgetrusty"));
         }
     };
 }


### PR DESCRIPTION
## Related Issue 
#108

## Description

 This PR introduces subagents as a first-class capability in LanguageModelRequestBuilder.

A subagent can now be defined directly from the request builder's dedicated subagent path; `.build()` produces a Tool instead of a LanguageModelRequest, while normal request building remains unchanged.

### The new API makes subagent creation explicit and type-safe:

  - normal requests continue to use prompt() or messages()
  - subagents are created with subagent(name, description)
  - once in subagent mode, conversation input methods are no longer available
  - The delegated task is supplied at tool-call time through the subagent input schema

### Example
```rs
let subagent = LanguageModelRequest::builder()
    .model(model)
    .subagent("explore-agent", "Explore the codebase to have a deeper understanding of the project.")
    .system("You are a research agent. Summarize your findings in your final response.")
    .with_tool(readFileTool())
    .with_tool(searchTool())
    .build(); // -> Tool

let main_agent = LanguageModelRequest::builder()
    .model(model)
    .system("You are a helpful assistant with access to tools.")
    .prompt("What is the secret code for lets")
    .with_tool(subagent) // pass the subagent to parent
    .build()
    .generate_text()
    .await?;
```