### PR TITLE
fix: enhance OpenAI streaming events with new response types and handling (gpt-5.5)

### DIFF
--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -314,13 +314,13 @@ pub(crate) fn merge_headers(
 ) -> Result<reqwest::header::HeaderMap> {
     if let Some(provider_headers) = provider_level {
         let provider_headers = reqwest::header::HeaderMap::try_from(provider_headers)
-            .map_err(|e| Error::InvalidInput(format!("Invalid headers: {}", e)))?;
+            .map_err(|e| Error::InvalidInput(format!("Invalid headers: {e}")))?;
         default_headers.extend(provider_headers);
     }
 
     if let Some(request_headers) = request_level {
         let request_headers = reqwest::header::HeaderMap::try_from(request_headers)
-            .map_err(|e| Error::InvalidInput(format!("Invalid headers: {}", e)))?;
+            .map_err(|e| Error::InvalidInput(format!("Invalid headers: {e}")))?;
         default_headers.extend(request_headers);
     }
 

--- a/src/integrations/vercel_aisdk_ui.rs
+++ b/src/integrations/vercel_aisdk_ui.rs
@@ -337,7 +337,6 @@ impl crate::core::StreamTextResponse {
             .unwrap_or_else(|| format!("msg_{}", uuid::Uuid::new_v4().simple()));
 
         let mut pending_tool_inputs: HashMap<String, String> = HashMap::new();
-
         self.stream.flat_map(move |chunk| {
             let ui_chunks = map_language_model_chunk_to_vercel_ui(
                 chunk,
@@ -370,11 +369,13 @@ fn map_language_model_chunk_to_vercel_ui(
             }
         }
 
-        LanguageModelStreamChunkType::TextDelta(delta) => vec![VercelUIStream::TextDelta {
-            id: message_id.to_string(),
-            delta,
-            provider_metadata: None,
-        }],
+        LanguageModelStreamChunkType::TextDelta(delta) => {
+            vec![VercelUIStream::TextDelta {
+                id: message_id.to_string(),
+                delta,
+                provider_metadata: None,
+            }]
+        }
 
         LanguageModelStreamChunkType::TextEnd => {
             if options.send_finish {

--- a/src/providers/openai/client/types.rs
+++ b/src/providers/openai/client/types.rs
@@ -82,6 +82,18 @@ impl OpenAILanguageModelOptions {
 #[serde(tag = "type")]
 /// Events emitted during streaming from OpenAI.
 pub(crate) enum OpenAiStreamEvent {
+    /// Emitted when the response object is created.
+    #[serde(rename = "response.created")]
+    ResponseCreated {
+        sequence_number: u64,
+        response: OpenAIResponse,
+    },
+    /// Emitted when the response transitions to in-progress.
+    #[serde(rename = "response.in_progress")]
+    ResponseInProgress {
+        sequence_number: u64,
+        response: OpenAIResponse,
+    },
     /// Emitted when the model response is complete.
     #[serde(rename = "response.completed")]
     ResponseCompleted {
@@ -94,6 +106,24 @@ pub(crate) enum OpenAiStreamEvent {
         sequence_number: u64,
         output_index: u32,
         item: MessageItem,
+    },
+    /// Emitted when a content part is added to an output item.
+    #[serde(rename = "response.content_part.added")]
+    ResponseContentPartAdded {
+        sequence_number: u64,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        part: OutputContent,
+    },
+    /// Emitted when a content part is finalized.
+    #[serde(rename = "response.content_part.done")]
+    ResponseContentPartDone {
+        sequence_number: u64,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        part: OutputContent,
     },
     /// Emitted when an output item is finalized.
     #[serde(rename = "response.output_item.done")]

--- a/src/providers/openai/language_model.rs
+++ b/src/providers/openai/language_model.rs
@@ -101,6 +101,22 @@ impl<M: ModelName> LanguageModel for OpenAI<M> {
         };
 
         let stream = openai_stream.map(|evt_res| match evt_res {
+            Ok(client::OpenAiStreamEvent::ResponseCreated { .. })
+            | Ok(client::OpenAiStreamEvent::ResponseInProgress { .. })
+            | Ok(client::OpenAiStreamEvent::ResponseContentPartDone { .. })
+            | Ok(client::OpenAiStreamEvent::ResponseOutputItemDone { .. }) => Ok(vec![]),
+
+            Ok(client::OpenAiStreamEvent::ResponseFunctionCallArgumentsDone { .. }) => Ok(vec![]),
+
+            Ok(client::OpenAiStreamEvent::ResponseContentPartAdded { part, .. }) => match part {
+                types::OutputContent::OutputText { .. } => {
+                    Ok(vec![LanguageModelStreamChunk::Delta(
+                        LanguageModelStreamChunkType::TextStart,
+                    )])
+                }
+                types::OutputContent::Refusal { .. } => Ok(vec![]),
+            },
+
             Ok(client::OpenAiStreamEvent::ResponseOutputItemAdded { item, .. }) => match item {
                 // Handle "start" events
                 types::MessageItem::FunctionCall { id, name, .. } => {
@@ -115,7 +131,6 @@ impl<M: ModelName> LanguageModel for OpenAI<M> {
                 types::MessageItem::Reasoning { .. } => Ok(vec![LanguageModelStreamChunk::Delta(
                     LanguageModelStreamChunkType::ReasoningStart,
                 )]),
-
                 types::MessageItem::OutputMessage { .. } => {
                     Ok(vec![LanguageModelStreamChunk::Delta(
                         LanguageModelStreamChunkType::TextStart,
@@ -380,8 +395,21 @@ mod tests {
             let request = String::from_utf8(buffer).expect("request should be valid utf-8");
             let response_body = concat!(
                 "data: {",
-                "\"type\":\"response.output_text.delta\",",
+                "\"type\":\"response.content_part.added\",",
                 "\"sequence_number\":1,",
+                "\"item_id\":\"msg_stream_1\",",
+                "\"output_index\":0,",
+                "\"content_index\":0,",
+                "\"part\":{",
+                "\"type\":\"output_text\",",
+                "\"text\":\"\",",
+                "\"annotations\":[],",
+                "\"logprobs\":[]",
+                "}",
+                "}\n\n",
+                "data: {",
+                "\"type\":\"response.output_text.delta\",",
+                "\"sequence_number\":2,",
                 "\"item_id\":\"item_1\",",
                 "\"output_index\":0,",
                 "\"content_index\":0,",
@@ -389,7 +417,7 @@ mod tests {
                 "}\n\n",
                 "data: {",
                 "\"type\":\"response.completed\",",
-                "\"sequence_number\":2,",
+                "\"sequence_number\":3,",
                 "\"response\":{",
                 "\"id\":\"resp_stream_1\",",
                 "\"model\":\"gpt-4o-mini\",",
@@ -648,20 +676,20 @@ mod tests {
             .await
             .expect("stream request should succeed");
 
-        let mut first_item = tokio::time::timeout(Duration::from_secs(1), stream.stream.next())
+        let first_item = tokio::time::timeout(Duration::from_secs(1), stream.stream.next())
             .await
             .expect("stream should yield an event")
             .expect("stream should not end immediately");
 
-        if matches!(
+        assert!(matches!(
             first_item,
             crate::core::language_model::LanguageModelStreamChunkType::TextStart
-        ) {
-            first_item = tokio::time::timeout(Duration::from_secs(1), stream.stream.next())
-                .await
-                .expect("stream should yield an event")
-                .expect("stream should not end immediately");
-        }
+        ));
+
+        let first_item = tokio::time::timeout(Duration::from_secs(1), stream.stream.next())
+            .await
+            .expect("stream should yield an event")
+            .expect("stream should not end immediately");
 
         match first_item {
             crate::core::language_model::LanguageModelStreamChunkType::TextDelta(text) => {
@@ -739,20 +767,20 @@ mod tests {
             .await
             .expect("stream request should succeed");
 
-        let mut first_item = tokio::time::timeout(Duration::from_secs(1), stream.stream.next())
+        let first_item = tokio::time::timeout(Duration::from_secs(1), stream.stream.next())
             .await
             .expect("stream should yield an event")
             .expect("stream should not end immediately");
 
-        if matches!(
+        assert!(matches!(
             first_item,
             crate::core::language_model::LanguageModelStreamChunkType::TextStart
-        ) {
-            first_item = tokio::time::timeout(Duration::from_secs(1), stream.stream.next())
-                .await
-                .expect("stream should yield an event")
-                .expect("stream should not end immediately");
-        }
+        ));
+
+        let first_item = tokio::time::timeout(Duration::from_secs(1), stream.stream.next())
+            .await
+            .expect("stream should yield an event")
+            .expect("stream should not end immediately");
 
         match first_item {
             crate::core::language_model::LanguageModelStreamChunkType::TextDelta(text) => {


### PR DESCRIPTION
## Background

When using `gpt-5.5`, the OpenAI streaming response included additional event types such as `response.created`, `response.in_progress`, and `response.content_part.added`. These events were not fully supported in the current stream handling logic, which caused the response flow to break and resulted in errors.

## Changes

- Added support for newly observed OpenAI streaming event types:
  - `response.created`
  - `response.in_progress`
  - `response.content_part.added`
  - `response.content_part.done`
- Updated streaming handling in the OpenAI language model implementation to safely ignore non-output lifecycle events and correctly initialize text output when `response.content_part.added` is received
- Adjusted related stream tests to reflect the updated event sequence
- Included minor cleanup changes from formatting and clippy fixes

## Expected Result
- `gpt-5.5` streaming responses are handled correctly
- Text output starts at the proper point in the event flow
- The previous runtime error caused by unhandled response events no longer occurs
Closes #[issue_number]

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.